### PR TITLE
adding retry logic to handle 502 errors

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -28,8 +28,17 @@ from .utils import extract_id, now
 
 
 def create_session():
+    """
+    retry on 502
+    """
     session = Session()
-    retry = Retry(total=5, backoff_factor=0.3, status_forcelist=(502,))
+    retry = Retry(
+        status=5,
+        backoff_factor=0.3,
+        status_forcelist=(502,),
+        # CAUTION: adding 'POST' to this list which is not technically idempotent
+        method_whitelist=("POST", "HEAD", "TRACE", "GET", "PUT", "OPTIONS", "DELETE"),
+    )
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("https://", adapter)
     return session


### PR DESCRIPTION
add retries, to address recent recurring 502 errors like this:


```
Traceback (most recent call last):
  File "notion/project/main.py", line 51, in <module>
    main()
  File "/Users/d/Projects/le/automation/.venv/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/d/Projects/le/automation/.venv/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/d/Projects/le/automation/.venv/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/d/Projects/le/automation/.venv/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "notion/project/main.py", line 44, in main
    templates.decisions.create(client, project_page)
  File "/Users/d/Projects/le/automation/notion/project/templates/decisions.py", line 62, in create
    page.children.add_new(HeaderBlock, title="Decisions")
  File "/Users/d/Projects/le/notion-py/notion/block.py", line 143, in add_new
    block, key
  File "/Users/d/Projects/le/notion-py/notion/client.py", line 297, in __exit__
    self.client.submit_transaction(operations)
  File "/Users/d/Projects/le/notion-py/notion/client.py", line 196, in submit_transaction
    self.post("submitTransaction", data).json()
  File "/Users/d/Projects/le/notion-py/notion/client.py", line 171, in post
    response.raise_for_status()
  File "/Users/d/Projects/le/automation/.venv/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: https://www.notion.so/api/v3/submitTransaction
```