### PR TITLE
raise custom exception for invalid ID

### DIFF
--- a/notion/utils.py
+++ b/notion/utils.py
@@ -9,6 +9,10 @@ from slugify import slugify as _dash_slugify
 from .settings import BASE_URL, SIGNED_URL_PREFIX, S3_URL_PREFIX, S3_URL_PREFIX_ENCODED
 
 
+class InvalidNotionIdentifier(Exception):
+    pass
+
+
 def now():
     return int(datetime.now().timestamp() * 1000)
 
@@ -20,8 +24,8 @@ def extract_id(url_or_id):
     block in a page), it will instead be the ID of that block. If it's already in ID format,
     it will be passed right through.
     """
-    if url_or_id.startswith("http"):
-        assert url_or_id.startswith(BASE_URL)
+    input_value = url_or_id
+    if url_or_id.startswith(BASE_URL):
         url_or_id = (
             url_or_id.split("#")[-1]
             .split("/")[-1]
@@ -29,7 +33,10 @@ def extract_id(url_or_id):
             .split("?")[0]
             .split("-")[-1]
         )
-    return str(uuid.UUID(url_or_id))
+    try:
+        return str(uuid.UUID(url_or_id))
+    except ValueError:
+        raise InvalidNotionIdentifier(input_value)
 
 
 def get_embed_data(source_url):


### PR DESCRIPTION
The current exception is not super helpful:

```
~/Projects/le/notion-py/notion/client.py in get_block(self, url_or_id, force_refresh)
     81         Retrieve an instance of a subclass of Block that maps to the block/page identified by the URL or ID passed in.
     82         """
---> 83         block_id = extract_id(url_or_id)
     84         block = self.get_record_data("block", block_id, force_refresh=force_refresh)
     85         if not block:

~/Projects/le/notion-py/notion/utils.py in extract_id(url_or_id)
     30             .split("-")[-1]
     31         )
---> 32     return str(uuid.UUID(url_or_id))
     33 
     34 

/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/uuid.py in __init__(self, hex, bytes, bytes_le, fields, int, version, is_safe)
    158             hex = hex.strip('{}').replace('-', '')
    159             if len(hex) != 32:
--> 160                 raise ValueError('badly formed hexadecimal UUID string')
    161             int = int_(hex, 16)
    162         if bytes_le is not None:

ValueError: badly formed hexadecimal UUID string
```

This PR explains what's happening a bit better:


```
~/Projects/le/notion-py/notion/client.py in get_block(self, url_or_id, force_refresh)
     81         Retrieve an instance of a subclass of Block that maps to the block/page identified by the URL or ID passed in.
     82         """
---> 83         block_id = extract_id(url_or_id)
     84         block = self.get_record_data("block", block_id, force_refresh=force_refresh)
     85         if not block:

~/Projects/le/notion-py/notion/utils.py in extract_id(url_or_id)
     37         return str(uuid.UUID(url_or_id))
     38     except ValueError:
---> 39         raise InvalidNotionIdentifier(input_value)
     40 

InvalidNotionIdentifier: https://www.notion.so/learningequality/
```