### PR TITLE
Fix Android Termux: "ImportError: cannot import name 'SemLock' from '_multiprocessing'"

### DIFF
--- a/notion/store.py
+++ b/notion/store.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from copy import deepcopy
 from dictdiffer import diff
 from inspect import signature
-from multiprocessing import Lock
+from threading import Lock
 from pathlib import Path
 from tzlocal import get_localzone
 


### PR DESCRIPTION
See #61.
Does notion-py actually use multiple processes?
If not maybe we can just switch to `threading.Lock`.