### PR TITLE
Fixed Notion pages mention bug and added function to get them

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -353,6 +353,13 @@ class CollectionRowBlock(PageBlock):
 
         return self._convert_notion_to_python(val, prop)
 
+    def get_mentioned_pages_on_property(self, identifier):
+        prop = self.collection.get_schema_property(identifier)
+        if prop is None:
+            raise AttributeError("Object does not have property '{}'".format(identifier))
+        val = self.get(["properties", prop["id"]])
+        return self._convert_mentioned_pages_to_python(val, prop)
+
     def _convert_diff_to_changelist(self, difference, old_val, new_val):
 
         changed_props = set()
@@ -385,9 +392,29 @@ class CollectionRowBlock(PageBlock):
             remaining, old_val, new_val
         )
 
+    def _convert_mentioned_pages_to_python(self, val, prop):
+        if not prop["type"] in ["title", "text"]:
+            raise TypeError("The property must be an title or text to convert mentioned pages to Python.")
+
+        pages = []
+        for i, part in enumerate(val):
+            if len(part) == 2:
+                for format in part[1]:
+                    if "p" in format:
+                        pages.append(self._client.get_block(format[1]))
+
+        return pages
+
     def _convert_notion_to_python(self, val, prop):
 
         if prop["type"] in ["title", "text"]:
+            for i, part in enumerate(val):
+                if len(part) == 2:
+                    for format in part[1]:
+                        if "p" in format:
+                            page = self._client.get_block(format[1])
+                            val[i] = (["[" + page.icon + " " + page.title + "](" + page.get_browseable_url() + ")"])
+
             val = notion_to_markdown(val) if val else ""
         if prop["type"] in ["number"]:
             if val is not None:


### PR DESCRIPTION
A sample database with fields filled with Notion pages mentions
![Screenshot_1836](https://user-images.githubusercontent.com/45729286/71555510-fc0def80-2a0b-11ea-9650-bc4fe3b9ef87.png)

The result when trying to get the value
![Screenshot_1840](https://user-images.githubusercontent.com/45729286/71555513-016b3a00-2a0c-11ea-9d2c-ce5b0e1e11cf.png)


---

The result with this fix
![Screenshot_1841](https://user-images.githubusercontent.com/45729286/71555771-2d87ba80-2a0e-11ea-9d69-641d8af71518.png)


And the new function to get the mentioned pages in a `PageBlock` array.
![Screenshot_1842](https://user-images.githubusercontent.com/45729286/71555779-4bedb600-2a0e-11ea-94e9-86f54739d0af.png)

