### PR TITLE
Fixes #52: switch get_rows to use queries, and allow query params

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -138,7 +138,7 @@ class NotionClient(object):
         self._store.call_get_record_values(**kwargs)
 
     def refresh_collection_rows(self, collection_id):
-        row_ids = self.search_pages_with_parent(collection_id)
+        row_ids = [row.id for row in self.get_collection(collection_id).get_rows()]
         self._store.set_collection_rows(collection_id, row_ids)
 
     def post(self, endpoint, data):

--- a/notion/smoke_test.py
+++ b/notion/smoke_test.py
@@ -102,6 +102,10 @@ def run_live_smoke_test(token_v2, parent_page_url_or_id):
     result = view.default_query().execute()
     assert row in result
 
+    # query the collection directly
+    assert row in cvb.collection.get_rows(search="reference")
+    assert row not in cvb.collection.get_rows(search="penguins")
+
     # Run an "aggregation" query
     aggregate_params = [
         {"property": "estimated_value", "aggregation_type": "sum", "id": "total_value"}


### PR DESCRIPTION
Fix https://github.com/jamalex/notion-py/issues/52 with changes to `get_rows` to keep up with changes in Notion, and re-allow query parameters.