### PR TITLE
Add NOTIONPY_LOG_LEVEL envvar to set log level (or disable logging)

### DIFF
--- a/notion/block.py
+++ b/notion/block.py
@@ -1,4 +1,3 @@
-import logging
 import mimetypes
 import os
 import random
@@ -139,7 +138,7 @@ class Children(object):
                     if hasattr(block, key):
                         setattr(block, key, val)
                     else:
-                        logging.warning(
+                        logger.warning(
                             "{} does not have attribute '{}' to be set; skipping.".format(
                                 block, key
                             )

--- a/notion/logger.py
+++ b/notion/logger.py
@@ -1,19 +1,38 @@
 import logging
+import os
 
 from .settings import LOG_FILE
 
 
+NOTIONPY_LOG_LEVEL = os.environ.get("NOTIONPY_LOG_LEVEL", "warning").lower()
+
 logger = logging.getLogger("notion")
-
-handler = logging.FileHandler(LOG_FILE)
-handler.setLevel(logging.WARN)
-
-formatter = logging.Formatter("\n%(asctime)s - %(levelname)s - %(message)s")
-handler.setFormatter(formatter)
-
-logger.addHandler(handler)
 
 
 def enable_debugging():
-    logger.setLevel(logging.DEBUG)
-    handler.setLevel(logging.DEBUG)
+    set_log_level(logging.DEBUG)
+
+def set_log_level(level):
+    logger.setLevel(level)
+    handler.setLevel(level)
+
+
+if NOTIONPY_LOG_LEVEL == "disabled":
+    handler = logging.NullHandler()
+    logger.addHandler(handler)
+else:
+    handler = logging.FileHandler(LOG_FILE)
+    formatter = logging.Formatter("\n%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    if NOTIONPY_LOG_LEVEL == "debug":
+        set_log_level(logging.DEBUG)
+    elif NOTIONPY_LOG_LEVEL == "info":
+        set_log_level(logging.INFO)
+    elif NOTIONPY_LOG_LEVEL == "warning":
+        set_log_level(logging.WARNING)
+    elif NOTIONPY_LOG_LEVEL == "error":
+        set_log_level(logging.ERROR)
+    else:
+        raise Exception("Invalid value for environment variable NOTIONPY_LOG_LEVEL: {}".format(NOTIONPY_LOG_LEVEL))


### PR DESCRIPTION
Addresses #56.

The NOTIONPY_LOG_LEVEL envvar can be set to any of:
- disabled
- debug
- info
- warning (default)
- error