### PR TITLE
Fix query handling and example format in response to Notion changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,20 +166,28 @@ for row in result:
     print(row)
 
 # Run an "aggregation" query
-aggregate_params = [{
+aggregations = [{
     "property": "estimated_value",
-    "aggregation_type": "sum",
+    "aggregator": "sum",
     "id": "total_value",
 }]
 result = cv.build_query(aggregate=aggregate_params).execute()
 print("Total estimated value:", result.get_aggregate("total_value"))
 
-# Run a "filtered" query
-filter_params = [{
-    "property": "assigned_to",
-    "comparator": "enum_contains",
-    "value": client.current_user,
-}]
+# Run a "filtered" query (inspect network tab in browser for examples, on queryCollection calls)
+filter_params = {
+    "filters": [{
+        "filter": {
+            "value": {
+                "type": "exact",
+                "value": {"table": "notion_user", "id": client.current_user.id}
+            },
+            "operator": "person_contains"
+        },
+        "property": "assigned_to"
+    }],
+    "operator": "and"
+}
 result = cv.build_query(filter=filter_params).execute()
 print("Things assigned to me:", result)
 

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -266,17 +266,22 @@ def _normalize_property_name(prop_name, collection):
         return prop["id"]
 
 
-def _normalize_query_list(query_list, collection):
-    query_list = deepcopy(query_list)
-    for item in query_list:
+def _normalize_query_data(data, collection, recursing=False):
+    if not recursing:
+        data = deepcopy(data)
+    if isinstance(data, list):
+        return [_normalize_query_data(item, collection, recursing=True) for item in data]
+    elif isinstance(data, dict):
         # convert slugs to property ids
-        if "property" in item:
-            item["property"] = _normalize_property_name(item["property"], collection)
+        if "property" in data:
+            data["property"] = _normalize_property_name(data["property"], collection)
         # convert any instantiated objects into their ids
-        if "value" in item:
-            if hasattr(item["value"], "id"):
-                item["value"] = item["value"].id
-    return query_list
+        if "value" in data:
+            if hasattr(data["value"], "id"):
+                data["value"] = data["value"].id
+        for key in data:
+            data[key] = _normalize_query_data(data[key], collection, recursing=True)
+    return data
 
 
 class CollectionQuery(object):
@@ -287,20 +292,21 @@ class CollectionQuery(object):
         search="",
         type="table",
         aggregate=[],
+        aggregations=[],
         filter=[],
-        filter_operator="and",
         sort=[],
         calendar_by="",
         group_by="",
     ):
+        assert not (aggregate and aggregations), "Use only one of `aggregate` or `aggregations` (old vs new format)"
         self.collection = collection
         self.collection_view = collection_view
         self.search = search
         self.type = type
-        self.aggregate = _normalize_query_list(aggregate, collection)
-        self.filter = _normalize_query_list(filter, collection)
-        self.filter_operator = filter_operator
-        self.sort = _normalize_query_list(sort, collection)
+        self.aggregate = _normalize_query_data(aggregate, collection)
+        self.aggregations = _normalize_query_data(aggregations, collection)
+        self.filter = _normalize_query_data(filter, collection)
+        self.sort = _normalize_query_data(sort, collection)
         self.calendar_by = _normalize_property_name(calendar_by, collection)
         self.group_by = _normalize_property_name(group_by, collection)
         self._client = collection._client
@@ -317,12 +323,13 @@ class CollectionQuery(object):
                 search=self.search,
                 type=self.type,
                 aggregate=self.aggregate,
+                aggregations=self.aggregations,
                 filter=self.filter,
-                filter_operator=self.filter_operator,
                 sort=self.sort,
                 calendar_by=self.calendar_by,
                 group_by=self.group_by,
             ),
+            self
         )
 
 
@@ -620,11 +627,13 @@ class Templates(Children):
 
 
 class QueryResult(object):
-    def __init__(self, collection, result):
+    def __init__(self, collection, result, query):
         self.collection = collection
         self._client = collection._client
         self._block_ids = self._get_block_ids(result)
         self.aggregates = result.get("aggregationResults", [])
+        self.aggregate_ids = [agg.get("id") for agg in (query.aggregate or query.aggregations)]
+        self.query = query
 
     def _get_block_ids(self, result):
         return result["blockIds"]
@@ -635,8 +644,8 @@ class QueryResult(object):
         return block
 
     def get_aggregate(self, id):
-        for agg in self.aggregates:
-            if id == agg["id"]:
+        for agg_id, agg in zip(self.aggregate_ids, self.aggregates):
+            if id == agg_id:
                 return agg["value"]
         return None
 

--- a/notion/smoke_test.py
+++ b/notion/smoke_test.py
@@ -81,45 +81,64 @@ def run_live_smoke_test(token_v2, parent_page_url_or_id):
 
     special_code = uuid.uuid4().hex[:8]
 
-    row = cvb.collection.add_row()
-    assert row.person == []
-    row.name = "Just some data"
-    row.title = "Can reference 'title' field too! " + special_code
-    assert row.name == row.title
-    row.check_yo_self = True
-    row.estimated_value = None
-    row.estimated_value = 42
-    row.files = [
+    # add a row
+    row1 = cvb.collection.add_row()
+    assert row1.person == []
+    row1.name = "Just some data"
+    row1.title = "Can reference 'title' field too! " + special_code
+    assert row1.name == row1.title
+    row1.check_yo_self = True
+    row1.estimated_value = None
+    row1.estimated_value = 42
+    row1.files = [
         "https://www.birdlife.org/sites/default/files/styles/1600/public/slide.jpg"
     ]
-    row.person = client.current_user
-    row.tags = None
-    row.tags = []
-    row.tags = ["A", "C"]
-    row.where_to = "https://learningequality.org"
-    row.category = "A"
-    row.category = ""
-    row.category = None
-    row.category = "B"
+    row1.tags = None
+    row1.tags = []
+    row1.tags = ["A", "C"]
+    row1.where_to = "https://learningequality.org"
+    row1.category = "A"
+    row1.category = ""
+    row1.category = None
+    row1.category = "B"
+
+    # add another row
+    row2 = cvb.collection.add_row(person=client.current_user, title="Metallic penguins")
+    assert row2.person == [client.current_user]
+    assert row2.name == "Metallic penguins"
+    row2.check_yo_self = False
+    row2.estimated_value = 22
+    row2.files = [
+        "https://www.picclickimg.com/d/l400/pict/223603662103_/Vintage-Small-Monet-and-Jones-JNY-Enamel-Metallic.jpg"
+    ]
+    row2.tags = ["A", "B"]
+    row2.where_to = "https://learningequality.org"
+    row2.category = "C"
 
     # Run a filtered/sorted query using the view's default parameters
     result = view.default_query().execute()
-    assert row in result
+    assert row1 == result[0]
+    assert row2 == result[1]
+    assert len(result) == 2
 
     # query the collection directly
-    assert row in cvb.collection.get_rows(search=special_code)
-    assert row not in cvb.collection.get_rows(search="otherworldly penguins")
+    assert row1 in cvb.collection.get_rows(search=special_code)
+    assert row2 not in cvb.collection.get_rows(search=special_code)
+    assert row1 not in cvb.collection.get_rows(search="penguins")
+    assert row2 in cvb.collection.get_rows(search="penguins")
 
     # search the entire space
-    assert row in client.search_blocks(search=special_code)
-    assert row not in client.search_blocks(search="otherworldly penguins")
+    assert row1 in client.search_blocks(search=special_code)
+    assert row1 not in client.search_blocks(search="penguins")
+    assert row2 not in client.search_blocks(search=special_code)
+    assert row2 in client.search_blocks(search="penguins")
 
     # Run an "aggregation" query
     aggregations = [
         {"property": "estimated_value", "aggregator": "sum", "id": "total_value"}
     ]
     result = view.build_query(aggregations=aggregations).execute()
-    assert result.get_aggregate("total_value") == 42
+    assert result.get_aggregate("total_value") == 64
 
     # Run a "filtered" query
     filter_params = {
@@ -129,19 +148,21 @@ def run_live_smoke_test(token_v2, parent_page_url_or_id):
                     "type": "exact",
                     "value": {"table": "notion_user", "id": client.current_user.id}
                 },
-                "operator": "enum_does_not_contain"
+                "operator": "person_does_not_contain"
             },
             "property": "person"
         }],
         "operator": "and"
     }
     result = view.build_query(filter=filter_params).execute()
-    assert row not in result
+    assert row1 in result
+    assert row2 not in result
 
     # Run a "sorted" query
-    sort_params = [{"direction": "descending", "property": "estimated_value"}]
+    sort_params = [{"direction": "ascending", "property": "estimated_value"}]
     result = view.build_query(sort=sort_params).execute()
-    assert row in result
+    assert row1 == result[1]
+    assert row2 == result[0]
 
     print(
         "Check it out and make sure it looks good, then press any key here to delete it..."

--- a/notion/smoke_test.py
+++ b/notion/smoke_test.py
@@ -115,20 +115,26 @@ def run_live_smoke_test(token_v2, parent_page_url_or_id):
     assert row not in client.search_blocks(search="otherworldly penguins")
 
     # Run an "aggregation" query
-    aggregate_params = [
-        {"property": "estimated_value", "aggregation_type": "sum", "id": "total_value"}
+    aggregations = [
+        {"property": "estimated_value", "aggregator": "sum", "id": "total_value"}
     ]
-    result = view.build_query(aggregate=aggregate_params).execute()
+    result = view.build_query(aggregations=aggregations).execute()
     assert result.get_aggregate("total_value") == 42
 
     # Run a "filtered" query
-    filter_params = [
-        {
-            "property": "person",
-            "comparator": "enum_does_not_contain",
-            "value": client.current_user.id,
-        }
-    ]
+    filter_params = {
+        "filters": [{
+            "filter": {
+                "value": {
+                    "type": "exact",
+                    "value": {"table": "notion_user", "id": client.current_user.id}
+                },
+                "operator": "enum_does_not_contain"
+            },
+            "property": "person"
+        }],
+        "operator": "and"
+    }
     result = view.build_query(filter=filter_params).execute()
     assert row not in result
 

--- a/notion/store.py
+++ b/notion/store.py
@@ -301,18 +301,18 @@ class RecordStore(object):
         search="",
         type="table",
         aggregate=[],
-        filter=[],
-        filter_operator="and",
+        aggregations=[],
+        filter={},
         sort=[],
         calendar_by="",
         group_by="",
     ):
 
+        assert not (aggregate and aggregations), "Use only one of `aggregate` or `aggregations` (old vs new format)"
+
         # convert singletons into lists if needed
         if isinstance(aggregate, dict):
             aggregate = [aggregate]
-        if isinstance(filter, dict):
-            filter = [filter]
         if isinstance(sort, dict):
             sort = [sort]
 
@@ -322,15 +322,15 @@ class RecordStore(object):
             "loader": {
                 "limit": 10000,
                 "loadContentCover": True,
-                "query": search,
+                "searchQuery": search,
                 "userLocale": "en",
                 "userTimeZone": str(get_localzone()),
                 "type": type,
             },
             "query": {
                 "aggregate": aggregate,
+                "aggregations": aggregations,
                 "filter": filter,
-                "filter_operator": filter_operator,
                 "sort": sort,
             },
         }


### PR DESCRIPTION
On Jan 9, Notion made changes to the API format for queries. This PR allows the new query format to be used, but manually constructed queries will need to be updated. See https://github.com/jamalex/notion-py/issues/94. 