### PR TITLE
Remove status keyword to urllib3.Retry to maintain Python 3.5 compatibility

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -33,7 +33,7 @@ def create_session():
     """
     session = Session()
     retry = Retry(
-        status=5,
+        5,
         backoff_factor=0.3,
         status_forcelist=(502,),
         # CAUTION: adding 'POST' to this list which is not technically idempotent


### PR DESCRIPTION
Error with Python 3.5.2 on the latest `notion-py`:

```
Traceback (most recent call last):
  File "confluence_to_notion.py", line 185, in <module>
    client = NotionClient(token_v2=notion_token)
  File "/usr/local/lib/python3.5/dist-packages/notion/client.py", line 55, in __init__
    self.session = create_session()
  File "/usr/local/lib/python3.5/dist-packages/notion/client.py", line 40, in create_session
    method_whitelist=("POST", "HEAD", "TRACE", "GET", "PUT", "OPTIONS", "DELETE"),
TypeError: __init__() got an unexpected keyword argument 'status'
```

I tested this on 3.5.2 and 3.7.6, seems to work for my [app](https://github.com/hmartiro/confluence_to_notion).