### PR TITLE
enable api usage without token_v2

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -51,7 +51,7 @@ class NotionClient(object):
     for internal use -- the main one you'll likely want to use is `get_block`.
     """
 
-    def __init__(self, token_v2, monitor=False, start_monitoring=False, enable_caching=False, cache_key=None):
+    def __init__(self, token_v2=None, monitor=False, start_monitoring=False, enable_caching=False, cache_key=None):
         self.session = create_session()
         self.session.cookies = cookiejar_from_dict({"token_v2": token_v2})
         if enable_caching:
@@ -65,7 +65,8 @@ class NotionClient(object):
                 self.start_monitoring()
         else:
             self._monitor = None
-        self._update_user_info()
+        if token_v2:
+            self._update_user_info()
 
     def start_monitoring(self):
         self._monitor.poll_async()


### PR DESCRIPTION
Howdy! Opening a pull request in case this is something you'd like to support. We're actually using notion-py to pull from public notion pages to support some of our content development. 

This small (but useful) PR allows notion-py to be used against public notion pages without registering token_v2.

Feel free to close if it's out of scope, but it would be nice to have this as part of the library instead of the wrapper overwrite we've written below 🙂: 

```
class NotionWrapper(NotionClient):
    def _update_user_info(self):
        pass
```