### PR TITLE
Added "cover" attributes for Page blocks

### DIFF
--- a/notion/block.py
+++ b/notion/block.py
@@ -533,7 +533,12 @@ class PageBlock(BasicBlock):
         api_to_python=add_signed_prefix_as_needed,
         python_to_api=remove_signed_prefix_as_needed,
     )
-
+    
+    cover = field_map(
+        "format.page_cover",
+        api_to_python=add_signed_prefix_as_needed,
+        python_to_api=remove_signed_prefix_as_needed,
+    )
 
 class BulletedListBlock(BasicBlock):
 
@@ -769,6 +774,12 @@ class CollectionViewPageBlock(CollectionViewBlock):
 
     icon = field_map(
         "format.page_icon",
+        api_to_python=add_signed_prefix_as_needed,
+        python_to_api=remove_signed_prefix_as_needed,
+    )
+    
+     cover = field_map(
+        "format.page_cover",
         api_to_python=add_signed_prefix_as_needed,
         python_to_api=remove_signed_prefix_as_needed,
     )

--- a/notion/block.py
+++ b/notion/block.py
@@ -778,7 +778,7 @@ class CollectionViewPageBlock(CollectionViewBlock):
         python_to_api=remove_signed_prefix_as_needed,
     )
     
-     cover = field_map(
+    cover = field_map(
         "format.page_cover",
         api_to_python=add_signed_prefix_as_needed,
         python_to_api=remove_signed_prefix_as_needed,


### PR DESCRIPTION
While the icons of Page blocks could easily be modified with the API, there was no functionality to modify the covers. I added the relevant attributes to Page Blocks and Collection View Page Blocks.