### PR TITLE
Fixed setup.py for new pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,25 @@
 import setuptools
 
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-reqs = parse_requirements("requirements.txt", session=False)
-install_requires = [str(ir.req) for ir in reqs]
+
+def get_requirements(fname):
+    "Takes requirements from requirements.txt and returns a list."
+    with open(fname) as fp:
+        reqs = list()
+        for lib in fp.read().split("\n"):
+            # Ignore pypi flags and comments
+            if not lib.startswith("-") or lib.startswith("#"):
+                reqs.append(lib.strip())
+        return reqs
+
+
+install_requires = get_requirements("requirements.txt")
 
 setuptools.setup(
     name="notion",
-    version="0.0.25",
+    version="0.0.26",
     author="Jamie Alexandre",
     author_email="jamalex+python@gmail.com",
     description="Unofficial Python API client for Notion.so",


### PR DESCRIPTION
Hey @jamalex! 

Thanks for building the notion API wrapper — I love building things with it. 👏

I've been trying to release my tool based on Notion.py on Homebrew, and it requires building packages from source. I noticed that Notion can't build  with the new pip: 

```bash
nate-macbook:~/c/notion-py master ls                                                                                                                                              (base)
LICENSE                   Makefile                  build/                    ezgif-3-a935fdcb7415.gif  notion.egg-info/          run_smoke_test.py
MANIFEST.in               README.md                 dist/                     notion/                   requirements.txt          setup.py
nate-macbook:~/c/notion-py master ls dist                                                                                                                                         (base)
notion-0.0.25-py3-none-any.whl  notion-0.0.25.tar.gz
nate-macbook:~/c/notion-py master ls build                                                                                                                                        (base)
bdist.macosx-10.15-x86_64/ lib/
nate-macbook:~/c/notion-py master cd dist                                                                                                                                         (base)
nate-macbook:~/c/n/dist ls                                                                                                                                                        (base)
notion-0.0.25-py3-none-any.whl  notion-0.0.25.tar.gz
nate-macbook:~/c/n/dist tar -zxf notion-0.0.25.tar.gz                                                                                                                             (base)
nate-macbook:~/c/n/dist ls                                                                                                                                                        (base)
notion-0.0.25/                  notion-0.0.25-py3-none-any.whl  notion-0.0.25.tar.gz
nate-macbook:~/c/n/dist which pip                                                                                                                                                 (base)
/Users/xnutsive/opt/anaconda3/bin/pip
nate-macbook:~/c/n/dist pip --version                                                                                                                                             (base)
pip 20.1.1 from /Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip (python 3.7)
nate-macbook:~/c/n/dist pip install -U pip                                                                                                                                        (base)
Requirement already up-to-date: pip in /Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages (20.1.1)
nate-macbook:~/c/n/dist pip install -v --no-deps --no-binary :all: ./notion-0.0.25/                                                                                               (base)
Non-user install because site-packages writeable
Created temporary directory: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-ephem-wheel-cache-ouztwz7m
Created temporary directory: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s
Initialized build tracking at /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s
Created build tracker: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s
Entered build tracker: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s
Created temporary directory: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-install-82jx6loh
Processing ./notion-0.0.25
  Created temporary directory: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-build-upe_2dk7
  Added file:///Users/xnutsive/code/notion-py/dist/notion-0.0.25 to build tracker '/private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s'
    Running setup.py (path:/private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-build-upe_2dk7/setup.py) egg_info for package from file:///Users/xnutsive/code/notion-py/dist/notion-0.0.25
    Created temporary directory: /private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-pip-egg-info-f_ey_8kz
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-build-upe_2dk7/setup.py", line 12, in <module>
        install_requires = [str(ir.req) for ir in reqs]
      File "/private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-build-upe_2dk7/setup.py", line 12, in <listcomp>
        install_requires = [str(ir.req) for ir in reqs]
    AttributeError: 'ParsedRequirement' object has no attribute 'req'
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Exception information:
Traceback (most recent call last):
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 188, in _main
    status = self.run(options, args)
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 185, in wrapper
    return func(self, options, args)
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 333, in run
    reqs, check_supported_wheels=not options.target_dir
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 179, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 362, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 314, in _get_abstract_dist_for
    abstract_dist = self.preparer.prepare_linked_requirement(req)
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 488, in prepare_linked_requirement
    req, self.req_tracker, self.finder, self.build_isolation,
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 91, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/distributions/sdist.py", line 40, in prepare_distribution_metadata
    self.req.prepare_metadata()
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 550, in prepare_metadata
    self.metadata_directory = self._generate_metadata()
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 530, in _generate_metadata
    details=self.name or "from {}".format(self.link)
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 73, in generate_metadata
    command_desc='python setup.py egg_info',
  File "/Users/xnutsive/opt/anaconda3/lib/python3.7/site-packages/pip/_internal/utils/subprocess.py", line 241, in call_subprocess
    raise InstallationError(exc_msg)
pip._internal.exceptions.InstallationError: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Removed file:///Users/xnutsive/code/notion-py/dist/notion-0.0.25 from build tracker '/private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s'
Removed build tracker: '/private/var/folders/4k/kk3m6tcs32j25wx615vcbddw0000gn/T/pip-req-tracker-i01dom7s'
```

This PR fixes that by implementing our own requirements parser (from txt to `install_requires`) that seems to work fine and build fine. I've also bumped the version to `0.2.26`. 

I know you don't have much time nowdays — this shouldn't break anything as it doesn't really change the code itself. Please do let me know if you need help combing through the other PRs, happy to help ;) 
