### PR TITLE
Recursively Search / Replace Unicode placeholder with Dashes

### DIFF
--- a/notion/markdown.py
+++ b/notion/markdown.py
@@ -176,12 +176,17 @@ def markdown_to_notion(markdown):
         elif item[0]:
             consolidated.append(item)
 
-    # reinstate the regular dashes
-    for item in consolidated:
-        item[0] = item[0].replace("⸻", "-")
+    return cleanup_dashes(consolidated)
 
-    return consolidated
+def cleanup_dashes(thing):
+    regex_pattern = re.compile('⸻|%E2%B8%BB')
+    if type(thing) is list:
+        for counter, value in enumerate(thing):
+            thing[counter] = cleanup_dashes(value)
+    elif type(thing) is str:
+        return regex_pattern.sub('-', thing)
 
+    return thing
 
 def notion_to_markdown(notion):
 


### PR DESCRIPTION
This is my proposed fix for #155. 

My issue was two-fold:
1. The place holder unicode character `⸻` was being URL encoded because it was part of link. The cleanup search and replace was never going to find that. We need to also look for a URL encoded version of the unicode placeholder `%E2%B8%BB` and swap that back too
2. In the case of a link, the URL encoded placeholder was occurring in the second string of the list. I'm not super familiar with the structure of the data, so I added a small function to recursively search and replace both the placeholder character and it's URL encoded varient across all strings in all lists. If the format of the data is essentially tuples, with only one layer of nesting this could be cleaned up a bit.

Example markdown that caused me grief and it's consolidated block data
`[some link](https://somejirainstance.atlassian.net/issues/?jql=issueKey%20in%20(ABC-123))`
```
[['some link',
  [['a',
    'https://somejirainstance.atlassian.net/issues/?jql=issueKey%20in%20(ABC%E2%B8%BB123)'
  ]]
]]
```

It seems to work fine for my case, but don't have much insight into the problems with code blocks that inspired the original change.