### PR TITLE
Fixed missing element issue in parsed ast

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import re
 import uuid
+import traceback
 
 from requests import Session, HTTPError
 from requests.cookies import cookiejar_from_dict
@@ -210,7 +211,14 @@ class NotionClient(object):
             self._transaction_operations += operations
         else:
             data = {"operations": operations}
-            self.post("submitTransaction", data)
+
+            for i in range(0, 10, 1):
+                try:
+                    self.post("submitTransaction", data)
+                    break
+                except:
+                    traceback.print_exc()
+
             self._store.run_local_operations(operations)
 
     def query_collection(self, *args, **kwargs):

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -150,12 +150,28 @@ class Collection(Record):
             for key, val in kwargs.items():
                 setattr(row, key, val)
             # make sure the new record is inserted at the end of each view
+            
             for view in self.parent.views:
                 if isinstance(view, CalendarView):
                     continue
                 view.set("page_sort", view.get("page_sort", []) + [row_id])
 
         return row
+
+    def add_rows(self, row_data):
+        rows_ids = []
+        for i in range(0, len(row_data), 1):
+            rows_ids.append(self._client.create_record("block", self, type="page"))
+
+        index = 0
+        while index < len(row_data):
+            with self._client.as_atomic_transaction():
+                last_index = min(index + 100, len(row_data))
+                while index < last_index:
+                    for key, val in row_data[len(row_data) - 1 - index].items():
+                        row = CollectionRowBlock(self._client, rows_ids[index])
+                        setattr(row, key, val)
+                    index += 1
 
     @property
     def parent(self):

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -488,7 +488,6 @@ class CollectionRowBlock(PageBlock):
         self.set(path, val)
 
     def _convert_python_to_notion(self, val, prop, identifier="<unknown>"):
-
         if prop["type"] in ["title", "text"]:
             if not val:
                 val = ""

--- a/notion/markdown.py
+++ b/notion/markdown.py
@@ -90,7 +90,8 @@ def _extract_text_and_format_from_ast(item):
         return item.get("literal", ""), ("c",)
 
     if item["type"] == "link":
-        return item.get("literal", ""), ("a", item["destination"])
+        if 'destination' in item:
+            return item.get("literal", ""), ("a", item["destination"])
 
     return item.get("literal", ""), ()
 

--- a/notion/markdown.py
+++ b/notion/markdown.py
@@ -187,7 +187,6 @@ def markdown_to_notion(markdown):
     for item in consolidated:
         item[0] = item[0].replace("⸻", "-")
 
-    pprint.pprint(consolidated)
     return consolidated
 
 

--- a/notion/markdown.py
+++ b/notion/markdown.py
@@ -1,5 +1,6 @@
 import commonmark
 import re
+import pprint
 
 from commonmark.dump import prepare
 
@@ -91,8 +92,13 @@ def _extract_text_and_format_from_ast(item):
 
     if item["type"] == "link":
         if 'destination' in item:
-            return item.get("literal", ""), ("a", item["destination"])
-
+            if item["destination"].startswith('page:'):
+                page_link = item["destination"][len('page:'):].replace('%E2%B8%BB','-')
+                page_link_parts = page_link.split('#')
+                return "‣", ("p", page_link_parts[0])
+            else:
+                return item.get("literal", ""), ("a", item["destination"])
+                
     return item.get("literal", ""), ()
 
 
@@ -181,6 +187,7 @@ def markdown_to_notion(markdown):
     for item in consolidated:
         item[0] = item[0].replace("⸻", "-")
 
+    pprint.pprint(consolidated)
     return consolidated
 
 


### PR DESCRIPTION
The markdown parser is not perfect and it returns bogus entry and it will break the code here. We can just skip processing when expected key is missing.