### PR TITLE
Adapt to Notion.so's API changes

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -463,7 +463,7 @@ class CollectionRowBlock(PageBlock):
             val = self.get(prop["type"])
             val = datetime.utcfromtimestamp(val / 1000)
         if prop["type"] in ["created_by", "last_edited_by"]:
-            val = self.get(prop["type"])
+            val = self.get(prop["type"] + "_id")
             val = self._client.get_user(val)
 
         return val


### PR DESCRIPTION
Notion.so's API has been changed recently.

Table's `created_by` and `last_edited_by` is now `created_by_id` and `last_edited_by_id`