### PR TITLE
pass id to get media assets properly

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -440,7 +440,7 @@ class CollectionRowBlock(PageBlock):
         if prop["type"] in ["file"]:
             val = (
                 [
-                    add_signed_prefix_as_needed(item[1][0][1], client=self._client)
+                    add_signed_prefix_as_needed(item[1][0][1], client=self._client, id=self.id)
                     for item in val
                     if item[0] != ","
                 ]

--- a/notion/maps.py
+++ b/notion/maps.py
@@ -35,7 +35,10 @@ def field_map(path, python_to_api=lambda x: x, api_to_python=lambda x: x):
 
     def fget(self):
         kwargs = {}
-        if "client" in signature(api_to_python).parameters:
+        if (
+            "client" in signature(api_to_python).parameters
+            and "id" in signature(api_to_python).parameters
+        ):
             kwargs["client"] = self._client
             kwargs["id"] = self.id
         return api_to_python(self.get(path), **kwargs)

--- a/notion/maps.py
+++ b/notion/maps.py
@@ -37,6 +37,7 @@ def field_map(path, python_to_api=lambda x: x, api_to_python=lambda x: x):
         kwargs = {}
         if "client" in signature(api_to_python).parameters:
             kwargs["client"] = self._client
+            kwargs["id"] = self.id
         return api_to_python(self.get(path), **kwargs)
 
     def fset(self, value):
@@ -74,13 +75,14 @@ def property_map(
             x = markdown_to_notion(x)
         return x
 
-    def api2py(x, client=None):
+    def api2py(x, client=None, id=''):
         x = x or [[""]]
         if markdown:
             x = notion_to_markdown(x)
         kwargs = {}
         if "client" in signature(api_to_python).parameters:
             kwargs["client"] = client
+            kwargs["id"] = id
         return api_to_python(x, **kwargs)
 
     return field_map(["properties", name], python_to_api=py2api, api_to_python=api2py)

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -60,13 +60,13 @@ def get_embed_link(source_url):
     return parse_qs(urlparse(url).query)["src"][0]
 
 
-def add_signed_prefix_as_needed(url, client=None):
+def add_signed_prefix_as_needed(url, client=None, id=""):
 
     if url is None:
         return
 
     if url.startswith(S3_URL_PREFIX):
-        url = SIGNED_URL_PREFIX + quote_plus(url)
+        url = SIGNED_URL_PREFIX + quote_plus(url) + "?table=block&id=" + id
         if client:
             url = client.session.head(url).headers.get("Location")
 


### PR DESCRIPTION
A quick fix to get assets(image, video) from Notion properly

They recently had a [Bug bash fix (September 2, 2020)](https://www.notion.so/What-s-New-157765353f2c4705bd45474e5ba8b46c)

Now table and id is required to access the final URL of Notion assets, or it emits error like below

```
{"errorId":"f245f61f-dc18-4c2c-9928-2a6e89443559","name":"ValidationError","message":"Must specify table and id."}
```
