### PR TITLE
Fixed could not convert string to float with comma

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -427,7 +427,7 @@ class CollectionRowBlock(PageBlock):
             val = notion_to_markdown(val) if val else ""
         if prop["type"] in ["number"]:
             if val is not None:
-                val = val[0][0]
+                val = val[0][0].replace(',', '')
                 if "." in val:
                     val = float(val)
                 else:


### PR DESCRIPTION
Numbers formatted in currencies have comas when the amount is over 1,000.00. 
I was getting the error "could not convert string to float" with my data :T 