### PR TITLE
I added TOC block and make inline math showing in a block's title

### DIFF
--- a/notion/block.py
+++ b/notion/block.py
@@ -453,6 +453,10 @@ class ColumnBlock(Block):
 
     _type = "column"
 
+class TableOfContentsBlock(Block):
+
+    _type = "table_of_contents"
+
 
 class BasicBlock(Block):
 
@@ -477,6 +481,27 @@ class BasicBlock(Block):
 
     def _str_fields(self):
         return super()._str_fields() + ["title"]
+        
+    title_list = field_map(
+        ["properties", "title"],
+        python_to_api=lambda x: [[x]],
+        api_to_python=lambda x: x,
+    )
+
+    def _get_title(self):
+        text=""
+        for list in self.title_list:
+            if list[0] == "⁍":
+                    text+=list[1][0][1]
+            else:
+                text+=list[0]
+        return text
+    @property
+    def title(self):
+        try:
+            return self._get_title()
+        except:
+            pass
 
 
 class TodoBlock(BasicBlock):


### PR DESCRIPTION
Hi,

Due to the latest update of notion.so - supporting inline math, there was the problem in the notion-py of not showing these inline math code in the title of the block. Thus, I added a feature that if the block(BasicBlock) has inline math(katex) code in its title, it will put that in the title. Additionally, I added Table of Contents block to distinguish it from other blocks. Please test and consider this feature. Thank you