### PR TITLE
Support guest user tokens

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -82,7 +82,14 @@ class NotionClient(object):
         records = self.post("loadUserContent", {}).json()["recordMap"]
         self._store.store_recordmap(records)
         self.current_user = self.get_user(list(records["notion_user"].keys())[0])
-        self.current_space = self.get_space(list(records["space"].keys())[0])
+
+        try:
+            self.current_space = self.get_space(list(records["space"].keys())[0])
+        except:
+            # if guest user, use fallback value for space_id
+            self.current_space = self.get_space(
+                list(records["space_view"].values())[0]["value"]["space_id"]
+            )
         return records
 
     def get_email_uid(self):


### PR DESCRIPTION
Resolves #180 

Guest users have an empty `space` dict in the `/loadUserContent` response where we normally fetch the space details. This change calls the `/getPublicSpaceData` endpoint with the `space_id` of the workspace the guest user has been invited to, to fetch the data when this occurs.

Could be pretty brittle as I've only tested it on my use case!