### PR TITLE
Update README.md with `cv.get("query2")`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ result = cv.build_query(sort=sort_params).execute()
 print("Sorted results, showing most valuable first:", result)
 ```
 
-Note: You can combine `filter`, `aggregate`, and `sort`. See more examples of queries by setting up complex views in Notion, and then inspecting `cv.get("query")`
+Note: You can combine `filter`, `aggregate`, and `sort`. See more examples of queries by setting up complex views in Notion, and then inspecting the full query: `cv.get("query2")`.
 
 You can also see [more examples in action in the smoke test runner](https://github.com/jamalex/notion-py/blob/master/notion/smoke_test.py). Run it using:
 


### PR DESCRIPTION
Updates readme docs with correction about `cv.get("query2")` instead of `cv.get("query")`

Mentioned here: https://github.com/jamalex/notion-py/issues/214