### PR TITLE
Add login with email and password feature

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -8,6 +8,7 @@ from requests.cookies import cookiejar_from_dict
 from urllib.parse import urljoin
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from getpass import getpass
 
 from .block import Block, BLOCK_TYPES
 from .collection import (
@@ -58,9 +59,15 @@ class NotionClient(object):
         start_monitoring=False,
         enable_caching=False,
         cache_key=None,
+        email=None,
+        password=None,
     ):
         self.session = create_session()
-        self.session.cookies = cookiejar_from_dict({"token_v2": token_v2})
+        if token_v2:
+            self.session.cookies = cookiejar_from_dict({"token_v2": token_v2})
+        else:
+            self._set_token(email=email, password=password)
+
         if enable_caching:
             cache_key = cache_key or hashlib.sha256(token_v2.encode()).hexdigest()
             self._store = RecordStore(self, cache_key=cache_key)
@@ -72,11 +79,18 @@ class NotionClient(object):
                 self.start_monitoring()
         else:
             self._monitor = None
-        if token_v2:
-            self._update_user_info()
+
+        self._update_user_info()
 
     def start_monitoring(self):
         self._monitor.poll_async()
+
+    def _set_token(self, email=None, password=None):
+        if not email:
+            email = input(f'Enter Your Notion Email\n')
+        if not password:
+            password = getpass(f'Enter Your Notion Password\n')
+        self.post("loginWithEmail", {"email":email,"password":password}).json()
 
     def _update_user_info(self):
         records = self.post("loadUserContent", {}).json()["recordMap"]


### PR DESCRIPTION
I think getting a token every time is cumbersome.
So I added login feature. 

```python
from notion.client import NotionClient

client = NotionClient(token_v2='123125fsdfadblahblahblah')
# Everytime I use notion-py, I need to get token

client = NotionClient()
# Enter email and password through CLI
client = NotionClient(email="your-email@domain.com", password="your-password")
# Enter email and password through script
```
you can fully automate what you want to do in the package using this feature.
