### PR TITLE
Added conversion support for markdown equations.

### DIFF
--- a/notion/markdown.py
+++ b/notion/markdown.py
@@ -1,5 +1,7 @@
 import commonmark
 import re
+import html
+from xml.dom import minidom
 
 from commonmark.dump import prepare
 
@@ -69,9 +71,9 @@ delimiters = {
     "\u3000",
 }
 
-_NOTION_TO_MARKDOWN_MAPPER = {"i": "☃", "b": "☃☃", "s": "~~", "c": "`"}
+_NOTION_TO_MARKDOWN_MAPPER = {"i": "☃", "b": "☃☃", "s": "~~", "c": "`", "e": "$$"}
 
-FORMAT_PRECEDENCE = ["s", "b", "i", "a", "c"]
+FORMAT_PRECEDENCE = ["s", "b", "i", "a", "c", "e"]
 
 
 def _extract_text_and_format_from_ast(item):
@@ -79,6 +81,10 @@ def _extract_text_and_format_from_ast(item):
     if item["type"] == "html_inline":
         if item.get("literal", "") == "<s>":
             return "", ("s",)
+        if item.get("literal", "").startswith('<latex'):
+            elem = minidom.parseString(item.get("literal", "") + '</latex>').documentElement
+            equation = elem.attributes['equation'].value
+            return "", ("e", equation)
 
     if item["type"] == "emph":
         return item.get("literal", ""), ("i",)
@@ -118,6 +124,11 @@ def markdown_to_notion(markdown):
         markdown = markdown.replace("~~", "<s>", 1)
         markdown = markdown.replace("~~", "</s>", 1)
 
+    # commonmark doesn't support latex blocks, so we need to handle it ourselves
+    def handle_latex(match):
+        return f'<latex equation="{html.escape(match.group(0)[2:-2])}">\u204d</latex>'
+    markdown = re.sub(r'(?<!\\\\|\$\$)(?:\\\\)*((\$\$)+)(?!(\$\$))(.+?)(?<!(\$\$))\1(?!(\$\$))', handle_latex, markdown)
+
     # we don't want to touch dashes, so temporarily replace them here
     markdown = markdown.replace("-", "⸻")
 
@@ -146,6 +157,12 @@ def markdown_to_notion(markdown):
 
             if item["type"] == "html_inline" and literal == "</s>":
                 format.remove(("s",))
+                literal = ""
+
+            if item["type"] == "html_inline" and literal == "</latex>":
+                for f in filter(lambda f: f[0] == 'e', format):
+                    format.remove(f)
+                    break
                 literal = ""
 
             if item["type"] == "softbreak":
@@ -227,7 +244,15 @@ def notion_to_markdown(notion):
             if f[0] == "a":
                 markdown += "["
 
-        markdown += stripped
+        # Check wheter a format modifies the content
+        content_changed = False
+        for f in sorted_format:
+            if f[0] == 'e':
+                markdown += f[1]
+                content_changed = True
+
+        if not content_changed:
+            markdown += stripped
 
         for f in reversed(sorted_format):
             if f[0] in _NOTION_TO_MARKDOWN_MAPPER:


### PR DESCRIPTION
I have noticed when you load a block which contains inline equations, for example  ($$A \leftarrow B$$), then it is rendered as a single character (⁍ / \u204d). This is mostly because the inline equation blocks are formatted the following way ` ["⁍", [["e","A \leftarrow B"]]]` which is currently not interpreted correctly.

This PR adds correct conversion from and to markdown for inline equations. While markdown does not natively support inline equations, I decided to use the same block enclosing notion uses ($$). 

Thanks in advance.

Example usage:
```
from notion.block import BulletedListBlock

newchild = page.children.add_new(BulletedListBlock, title="Some fancy equation: $$y = ax + b$$...")
```