### PR TITLE
Support adding a row from a template

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from getpass import getpass
+from time import sleep
 
 from .block import Block, BLOCK_TYPES
 from .collection import (
@@ -373,7 +374,46 @@ class NotionClient(object):
                 )
 
         return record_id
+    
+    def get_task_status(self, task_id):
+        """
+        Get a status of a single task
+        """
+        data = self.post(
+            "getTasks",
+            {
+                "taskIds": [task_id]
+            }
+        ).json()
 
+        results = data.get("results")
+        if results is None:
+            return None
+        
+        if not results:
+            # Notion does not know about such a task
+            print("Invalid task ID.")
+            return None
+
+        if len(results) == 1:
+            state = results[0].get("state")
+            return state
+        
+        return None
+        
+    def wait_for_task(self, task_id, interval=1, tries=5):
+        """
+        Wait for a task by looping 'tries' times ever 'interval' seconds.
+        The 'interval' parameter can be used to specify milliseconds using double (e.g 0.75).
+        """
+        for i in range(tries):
+            state = self.get_task_status(task_id)
+            if state in ["not_started", "in_progress"]:
+                sleep(interval)
+            elif state == "success":
+                return state
+        
+        print("Task takes more time than expected. Specify 'interval' or 'tries' to wait more.")
 
 class Transaction(object):
 

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -186,14 +186,40 @@ class Collection(Record):
                 return prop
         return None
 
-    def add_row(self, update_views=True, **kwargs):
+    def add_row(self, update_views=True, sourceBlockId=None, **kwargs):
         """
         Create a new empty CollectionRowBlock under this collection, and return the instance.
+        Specify 'sourceBlockId' to create a row from a template block.
         """
 
         row_id = self._client.create_record("block", self, type="page")
         row = CollectionRowBlock(self._client, row_id)
 
+        # User wants to create a row from a template
+        if sourceBlockId:
+            # The source block can be either an ID or a URL
+            source_block = self._client.get_block(sourceBlockId)
+            # Start a duplication task
+            data = self._client.post(
+                "enqueueTask",
+                {
+                    "task": {
+                        "eventName": "duplicateBlock",
+                        "request": {
+                            "sourceBlockId": source_block.id,
+                            "targetBlockId": row_id,
+                            "appendContentOnly": True
+                        }
+                    }
+                },
+            ).json()
+
+            task_id = data.get("taskId")
+
+            if task_id:
+                # Wait until the duplication task finishes
+                self._client.wait_for_task(task_id)
+            
         with self._client.as_atomic_transaction():
             for key, val in kwargs.items():
                 setattr(row, key, val)


### PR DESCRIPTION
Hey :wave: 
This pull request implements a naive way to add a new row to a collection where its origin is a template (another block_id).

The implementation is based on a sequence of API calls:
* Enqueue a new task of type `duplicateBlock` (API: `v3/enqueueTask`)
* Loop `N` times every `X` seconds (or milliseconds) and check the status of the task (API: `v3/getTasks`)

The usage is very straightforward:

```python
cv = client.get_collection_view("...")
cv.collection.add_row(sourceBlockId="75dd203a-EXAMPLE-a12b-ba492c37a1f6")
```

And of course, more parameters can be added:

```python
cv.collection.add_row(
    sourceBlockId="75dd203a-EXAMPLE-a12b-ba492c37a1f6",
    name="The Hen House: Episode #123",
    type="Podcast"
)
```

**Note:**
The `v3/getTasks` actually supports getting the status of multiple tasks. I used it to get the status of a single one. We can consider improving it to support multiple tasks but didn't find it useful in the current design.

closes #194