### PR TITLE
Update schema

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -150,6 +150,26 @@ class Collection(Record):
         python_to_api=markdown_to_notion,
     )
     cover = field_map("cover")
+    _schema_types = [
+        "number",
+        "select",
+        "multi_select",
+        "date",
+        "person",
+        "file",
+        "checkbox",
+        "url",
+        "email",
+        "phone_number",
+        "created_time",
+        "created_by",
+        "last_edited_time",
+        "last_edited_by",
+        "formula",
+        "rollup",
+        # "relation"  # another contract for this type, requires another db at creation time
+    ]
+
 
     @property
     def templates(self):
@@ -158,6 +178,39 @@ class Collection(Record):
             self._client.refresh_records(block=template_ids)
             self._templates = Templates(parent=self)
         return self._templates
+
+    def update_schema_properties(self, props):
+        """
+        Update current schema with props.
+        Change the current properties is not supported fow now. The steps to produce such feature:
+        - find notion scheme property id by name (the original id in collection are random, or base64)
+        - update current scheme with props found id
+        """
+        schema = dict()
+        for prop in self.get_schema_properties():
+            schema.update({
+                prop["id"]: dict(
+                    name=prop["name"],
+                    type=prop["type"]
+                )
+            })
+        # check that props has a valid type
+        for _id, prop in props.items():
+            if prop["type"] not in self._schema_types:
+                logger.error("The type {} is unsupported.".format(prop["type"]))
+                return
+
+        logger.debug("Update current schema: {} with {}".format(schema, props))
+        schema.update(props)
+        self._client.submit_transaction(
+            build_operation(
+                id=self.id,
+                path=[],
+                args=dict(schema=schema),
+                command="update",
+                table="collection",
+            )
+        )
 
     def get_schema_properties(self):
         """

--- a/notion/smoke_test.py
+++ b/notion/smoke_test.py
@@ -200,6 +200,20 @@ def run_live_smoke_test(token_v2, parent_page_url_or_id):
     assert row1.some_date.timezone == timezone
     assert row1.some_date.reminder == reminder
 
+    # Test update schema with new props
+    for type_ in ["number", "select", "multi_select", "date", "person", "file", "checkbox", "url", "email",
+                  "phone_number", "created_time", "created_by", "last_edited_time", "last_edited_by", "formula",
+                  "rollup",
+                  # "relation"  # another contract for this type, requires another db at creation time
+                  ]:
+        cvb.collection.update_schema_properties({
+            type_: dict(
+                name=type_,
+                type=type_
+            )
+        })
+        assert cvb.collection.get_schema_property(type_)
+
     print(
         "Check it out and make sure it looks good, then press any key here to delete it..."
     )


### PR DESCRIPTION
Hi!

I was surprised that creation collection properties is not yet available. So here it is!

This PR does not provide:
1. "update" of current properties (change types)
2. "delete" current properties

So only add new property.

The smoke_tests are fine, but with only "edit" perms there are errors:
1. The search the whole space does not work
```python
# search the entire space
assert row1 in client.search_blocks(search=special_code)
assert row1 not in client.search_blocks(search="penguins")
assert row2 not in client.search_blocks(search=special_code)
assert row2 in client.search_blocks(search="penguins")
```
2. The deletion does not work 

Maybe the smoke tests instruction needs update that smoke tests requires admin perms?

Thanks in advance!