### PR TITLE
Hotfix empty props at type select

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -176,7 +176,12 @@ class Collection(Record):
         Check and update the prop dict with new values
         """
         schema_update = False
-        current_options = list([p["value"].lower() for p in prop["options"]])
+        current_options = []
+        try:
+            current_options = list([p["value"].lower() for p in prop["options"]])
+        except KeyError:
+            logger.warning("Prop may not have options {}".format(prop))
+            prop["options"] = []
         if not isinstance(values, list):
             values = [values]
         for v in values:

--- a/notion/smoke_test.py
+++ b/notion/smoke_test.py
@@ -142,6 +142,15 @@ def run_live_smoke_test(token_v2, parent_page_url_or_id):
             == get_collection_schema()[prop]["options"][0]["id"]
         )
 
+    # check that insert in empty props works
+    assert not row2.eselect
+    row2.eselect = "A"
+    assert cvb.collection.get("schema.{}.options.0.value".format("eselect")) == "A"
+
+    assert not row2.emselect
+    row2.emselect = ["A", "B"]
+    assert cvb.collection.get("schema.{}.options.0.value".format("emselect")) == "A"
+
     # Run a filtered/sorted query using the view's default parameters
     result = view.default_query().execute()
     assert row1 == result[0]


### PR DESCRIPTION
Hi!

In most cases all of the users will be using the existence tables or created by hands with all necessary props, but not me. I created an empty table and tried to insert options, that does not happen.

This PR fix the problem created at #252. 