### PR TITLE
[DRAFT] Added option to update reminders on CollectionRowBlock

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -549,7 +549,8 @@ class CollectionRowBlock(PageBlock):
             allprops[propid] = self.get_property(propid)
         return allprops
 
-    def set_property(self, identifier, val):
+#added a parameter to toggle when user needs to change the reminder with the NotioDate
+    def set_property(self, identifier, val, reminder=None):
 
         prop = self.collection.get_schema_property(identifier)
         if prop is None:
@@ -562,6 +563,37 @@ class CollectionRowBlock(PageBlock):
                 self.collection.set(
                     "schema.{}.options".format(prop["id"]), prop["options"]
                 )
+        #created a function to check if reminder dict has the correct keys and return NotionDate
+        #object in the correct format with updated reminder
+        def set_reminder(date, reminder):
+            try:
+                unit = reminder['unit']
+                value = reminder['value']
+            except:
+                raise AttributeError(
+                    "unit and value keys cannot be empty in reminder dictionary."
+                )
+            # "time" variable can be null, and usually will be ignored by Notion API
+            try:
+                reminder['time']
+            except:
+                reminder['time'] = None
+            #setting new reminder to the NotionDate object
+            date.reminder = {
+                'time':reminder['time'],
+                'unit': unit,
+                'value':value
+            }
+            return date
+        #if reminder is not null and prop type is date, update val.reminder before sending to the API
+        if reminder != None and prop['type'] in ['date']:
+            #if val is not a dict it is in wrong format
+            if type(reminder) != dict:
+                raise TypeError(
+                "reminder parameter must be a dict."
+            )
+            #set_reminder funct will return the updated NotionDate object
+            val = set_reminder(self.get_property(identifier), reminder)
 
         path, val = self._convert_python_to_notion(val, prop, identifier=identifier)
 

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -549,8 +549,7 @@ class CollectionRowBlock(PageBlock):
             allprops[propid] = self.get_property(propid)
         return allprops
 
-#added a parameter to toggle when user needs to change only the reminder
-    def set_property(self, identifier, val, reminder=False):
+    def set_property(self, identifier, val):
 
         prop = self.collection.get_schema_property(identifier)
         if prop is None:
@@ -563,38 +562,6 @@ class CollectionRowBlock(PageBlock):
                 self.collection.set(
                     "schema.{}.options".format(prop["id"]), prop["options"]
                 )
-        #created a function to check if val is in correct format and return NotionDate
-        #object in the correct format with updated reminder
-        def set_reminder(date, val):
-            try:
-                unit = val['unit']
-                value = val['value']
-            except:
-                raise AttributeError(
-                    "unit and value keys cannot be empty in val dictionary."
-                )
-            # "time" variable can be null, and usually will be ignored by Notion API
-            try:
-                val['time']
-            except:
-                val['time'] = None
-            #setting new reminder to the NotionDate object
-            date.reminder = {
-                'time':val['time'],
-                'unit': unit,
-                'value':value
-            }
-            return date
-
-        #if reminder is True and prop type is date, update reminder before sending to the API
-        if reminder and prop['type'] in ['date']:
-            #if val is not a dict it is in wrong format
-            if type(val) != dict:
-                raise TypeError(
-                "val parameter must be a dict."
-            )
-            #set_reminder funct will return the updated NotionDate object
-            val = set_reminder(self.get_property(identifier), val)
 
         path, val = self._convert_python_to_notion(val, prop, identifier=identifier)
 


### PR DESCRIPTION
+ As discussed in Issue #276 I added the option to update reminders on NotionDate objects. I would be done by a code like this:

```
from notion_dev.client import NotionClient

client = NotionClient(token_v2 = TOKEN)
page = client.get_block(BLOCK_REFERENCE)
col = client.get_collection('f963b90f-5e3c-463a-b22d-375ecbdc8a0b').get_rows()[-1]

date = col.get_property("Date")
reminder = {
    'time':'09:00',
    'unit':'day',
    'value':25
}
col.set_property('Date', date, reminder=reminder)
```

+ With this approach, users can opt to change the reminder easily when setting/updating a date property. Just need to add the dictionary to the function call. There are some Exceptions that I raised in the code that need to be reviewed and probably standardized with others. Also there are comments in each modification so you can understand better what login I used. 

+ Tell me if I need to change or review something. This is my first PR to this Repo so, sorry if made any obvious mistake. 😞