### PR TITLE
fix: change regex strings to raw

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -96,7 +96,7 @@ class NotionClient(object):
 
     def start_monitoring(self):
         self._monitor.poll_async()
-    
+
     def _fetch_guest_space_data(self, records):
         """
         guest users have an empty `space` dict, so get the space_id from the `space_view` dict instead,
@@ -209,7 +209,7 @@ class NotionClient(object):
         """
         # if it's a URL for a database page, try extracting the collection and view IDs
         if url_or_id.startswith("http"):
-            match = re.search("([a-f0-9]{32})\?v=([a-f0-9]{32})", url_or_id)
+            match = re.search(r"([a-f0-9]{32})\?v=([a-f0-9]{32})", url_or_id)
             if not match:
                 raise Exception("Invalid collection view URL")
             block_id, view_id = match.groups()

--- a/notion/markdown.py
+++ b/notion/markdown.py
@@ -230,7 +230,7 @@ def notion_to_markdown(notion):
         format = item[1] if len(item) == 2 else []
 
         match = re.match(
-            "^(?P<leading>\s*)(?P<stripped>(\s|.)*?)(?P<trailing>\s*)$", text
+            r"^(?P<leading>\s*)(?P<stripped>(\s|.)*?)(?P<trailing>\s*)$", text
         )
         if not match:
             raise Exception("Unable to extract text from: %r" % text)

--- a/notion/monitor.py
+++ b/notion/monitor.py
@@ -29,12 +29,12 @@ class Monitor(object):
 
         thing = thing.decode().strip()
 
-        for ping in re.findall('\d+:\d+"primus::ping::\d+"', thing):
+        for ping in re.findall(r'\d+:\d+"primus::ping::\d+"', thing):
             logger.debug("Received ping: {}".format(ping))
             self.post_data(ping.replace("::ping::", "::pong::"))
 
         results = []
-        for blob in re.findall("\d+:\d+(\{.*?\})(?=\d|$)", thing):
+        for blob in re.findall(r"\d+:\d+(\{.*?\})(?=\d|$)", thing):
             results.append(json.loads(blob))
         if thing and not results and "::ping::" not in thing:
             logger.debug("Could not parse monitoring response: {}".format(thing))
@@ -184,7 +184,7 @@ class Monitor(object):
 
                 if key.startswith("versions/"):
 
-                    match = re.match("versions/([^\:]+):(.+)", key)
+                    match = re.match(r"versions/([^\:]+):(.+)", key)
                     if not match:
                         continue
 
@@ -209,7 +209,7 @@ class Monitor(object):
 
                 if key.startswith("collection/"):
 
-                    match = re.match("collection/(.+)", key)
+                    match = re.match(r"collection/(.+)", key)
                     if not match:
                         continue
 


### PR DESCRIPTION
Some warnings are being raised in testing due to [escaped sequences](https://bugs.python.org/issue27364). Changing regex expressions in classes to raw strings.