### PR TITLE
Added rate limit to Notion API server

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -159,15 +159,15 @@ class NotionClient(object):
         records = self._update_user_info()
         return [self.get_block(bid) for bid in records["block"].keys()]
 
-    def get_record_data(self, table, id, force_refresh=False):
-        return self._store.get(table, id, force_refresh=force_refresh)
+    def get_record_data(self, table, id, force_refresh=False, limit=100):
+        return self._store.get(table, id, force_refresh=force_refresh, limit=limit)
 
-    def get_block(self, url_or_id, force_refresh=False):
+    def get_block(self, url_or_id, force_refresh=False, limit=100):
         """
         Retrieve an instance of a subclass of Block that maps to the block/page identified by the URL or ID passed in.
         """
         block_id = extract_id(url_or_id)
-        block = self.get_record_data("block", block_id, force_refresh=force_refresh)
+        block = self.get_record_data("block", block_id, force_refresh=force_refresh, limit=limit)
         if not block:
             return None
         if block.get("parent_table") == "collection":
@@ -310,11 +310,11 @@ class NotionClient(object):
         """
         return hasattr(self, "_transaction_operations")
 
-    def search_pages_with_parent(self, parent_id, search=""):
+    def search_pages_with_parent(self, parent_id, search="", limit=100):
         data = {
             "query": search,
             "parentId": parent_id,
-            "limit": 10000,
+            "limit": limit,
             "spaceId": self.current_space.id,
         }
         response = self.post("searchPagesWithParent", data).json()

--- a/notion/client.py
+++ b/notion/client.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from getpass import getpass
+from ratelimit import limits, sleep_and_retry
 
 from .block import Block, BLOCK_TYPES
 from .collection import (
@@ -244,6 +245,9 @@ class NotionClient(object):
     def refresh_collection_rows(self, collection_id):
         row_ids = [row.id for row in self.get_collection(collection_id).get_rows()]
         self._store.set_collection_rows(collection_id, row_ids)
+
+    @sleep_and_retry
+    @limits(calls=1, period=1)
 
     def post(self, endpoint, data):
         """

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -360,6 +360,7 @@ class CollectionQuery(object):
         sort=[],
         calendar_by="",
         group_by="",
+        limit=100
     ):
         assert not (
             aggregate and aggregations
@@ -374,25 +375,40 @@ class CollectionQuery(object):
         self.sort = _normalize_query_data(sort, collection)
         self.calendar_by = _normalize_property_name(calendar_by, collection)
         self.group_by = _normalize_property_name(group_by, collection)
+        self.limit = limit
         self._client = collection._client
 
     def execute(self):
 
         result_class = QUERY_RESULT_TYPES.get(self.type, QueryResult)
 
+        kwargs = {
+            'collection_id':self.collection.id,
+            'collection_view_id':self.collection_view.id,
+            'search':self.search,
+            'type':self.type,
+            'aggregate':self.aggregate,
+            'aggregations':self.aggregations,
+            'filter':self.filter,
+            'sort':self.sort,
+            'calendar_by':self.calendar_by,
+            'group_by':self.group_by,
+            'limit':0
+        }
+
+        if self.limit == -1:
+            # fetch remote total 
+            result = self._client.query_collection(
+                **kwargs
+            )
+            self.limit = result.get("total",-1)
+
+        kwargs['limit'] = self.limit
+
         return result_class(
             self.collection,
             self._client.query_collection(
-                collection_id=self.collection.id,
-                collection_view_id=self.collection_view.id,
-                search=self.search,
-                type=self.type,
-                aggregate=self.aggregate,
-                aggregations=self.aggregations,
-                filter=self.filter,
-                sort=self.sort,
-                calendar_by=self.calendar_by,
-                group_by=self.group_by,
+                **kwargs
             ),
             self,
         )
@@ -704,6 +720,7 @@ class QueryResult(object):
         self.collection = collection
         self._client = collection._client
         self._block_ids = self._get_block_ids(result)
+        self.total = result.get("total", -1)
         self.aggregates = result.get("aggregationResults", [])
         self.aggregate_ids = [
             agg.get("id") for agg in (query.aggregate or query.aggregations)
@@ -753,7 +770,6 @@ class QueryResult(object):
         else:
             return False
         return item_id in self._block_ids
-
 
 class TableQueryResult(QueryResult):
 

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -271,6 +271,22 @@ class CollectionView(Record):
         assert self.get("parent_table", "block")
         return self._client.get_block(self.get("parent_id"))
 
+    @property
+    def columns(self):
+        columns = list()
+
+        for prop in self.get("format.table_properties"):
+            schema = self.collection.get_schema_property(prop["property"])
+            columns.append({
+                "name" : schema["name"],
+                "id" : schema["id"],
+                "width" : prop["width"],
+                "visible" : prop["visible"],
+                "type" : schema["type"]
+            })
+
+        return columns
+
     def __init__(self, *args, collection, **kwargs):
         self.collection = collection
         super().__init__(*args, **kwargs)

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -281,7 +281,7 @@ class CollectionView(Record):
         )
 
     def default_query(self):
-        return self.build_query(**self.get("query", {}))
+        return self.build_query(**self.get("query2", {}))
 
 
 class BoardView(CollectionView):

--- a/notion/collection.py
+++ b/notion/collection.py
@@ -100,6 +100,20 @@ class NotionDate(object):
 
         return [["‣", [["d", data]]]]
 
+    def __repr__(self):
+        string = ""
+
+        start_date, start_time = self._format_datetime(self.start)
+        if start_date: string += start_date
+        if start_time: string += "T" + start_time
+
+        end_date, end_time = self._format_datetime(self.end)
+        if end_date: string += ";" + end_date
+        if end_time: string += "T" + end_time
+
+        # TODO if self.reminder:
+
+        return string
 
 class NotionSelect(object):
     valid_colors = [

--- a/notion/store.py
+++ b/notion/store.py
@@ -174,14 +174,14 @@ class RecordStore(object):
         self.get(table, id, force_refresh=force_refresh)
         return self._role[table].get(id, None)
 
-    def get(self, table, id, force_refresh=False):
+    def get(self, table, id, force_refresh=False, limit=100):
         id = extract_id(id)
         # look up the record in the current local dataset
         result = self._get(table, id)
         # if it's not found, try refreshing the record from the server
         if result is Missing or force_refresh:
             if table == "block":
-                self.call_load_page_chunk(id)
+                self.call_load_page_chunk(id,limit=limit)
             else:
                 self.call_get_record_values(**{table: id})
             result = self._get(table, id)
@@ -269,7 +269,7 @@ class RecordStore(object):
         else:
             return -1
 
-    def call_load_page_chunk(self, page_id):
+    def call_load_page_chunk(self, page_id, limit=100):
 
         if self._client.in_transaction():
             self._pages_to_refresh.append(page_id)
@@ -277,7 +277,7 @@ class RecordStore(object):
 
         data = {
             "pageId": page_id,
-            "limit": 100000,
+            "limit": limit,
             "cursor": {"stack": []},
             "chunkNumber": 0,
             "verticalColumns": False,
@@ -310,6 +310,7 @@ class RecordStore(object):
         sort=[],
         calendar_by="",
         group_by="",
+        limit=50
     ):
 
         assert not (
@@ -326,7 +327,7 @@ class RecordStore(object):
             "collectionId": collection_id,
             "collectionViewId": collection_view_id,
             "loader": {
-                "limit": 10000,
+                "limit": limit,
                 "loadContentCover": True,
                 "searchQuery": search,
                 "userLocale": "en",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tzlocal
 python-slugify
 dictdiffer
 cached-property
+ratelimit


### PR DESCRIPTION
Added a "one request per second" rate limit to the Notion API calls.

There may be more granular call / period, but this seems to work for 1000+ calls over a period of time w/out causing any 429 errors.

Fix issue #301