### PR TITLE
Fix Invalid Input error for get_collection_view()

### DIFF
--- a/notion/store.py
+++ b/notion/store.py
@@ -276,8 +276,10 @@ class RecordStore(object):
             return
 
         data = {
-            "pageId": page_id,
-            "limit": 100000,
+            "page": {
+                "id": page_id
+            },
+            "limit": 100,
             "cursor": {"stack": []},
             "chunkNumber": 0,
             "verticalColumns": False,


### PR DESCRIPTION
Fixes #301

- loadPageChunk API requires Page ID as an object
- limit needs to be <= 100