### PR TITLE
Fix EquationBlock.latex

### DIFF
--- a/notion/block.py
+++ b/notion/block.py
@@ -588,7 +588,7 @@ class EquationBlock(BasicBlock):
     latex = field_map(
         ["properties", "title"],
         python_to_api=lambda x: [[x]],
-        api_to_python=lambda x: x[0][0],
+        api_to_python=lambda x: x[0][0] if x else "",
     )
 
     _type = "equation"


### PR DESCRIPTION
It's for making the following code work:

```
page.children.add_new(EquationBlock, latex="a = b")
```