### PR TITLE
Fix for urllib3 retry parameter method_whitelist rename

### DIFF
--- a/notion/client.py
+++ b/notion/client.py
@@ -41,7 +41,7 @@ def create_session(client_specified_retry=None):
             backoff_factor=0.3,
             status_forcelist=(502, 503, 504),
             # CAUTION: adding 'POST' to this list which is not technically idempotent
-            method_whitelist=(
+            allowed_methods=(
                 "POST",
                 "HEAD",
                 "TRACE",


### PR DESCRIPTION
For the `ullib3` Retry func, the parameter `method_whitelist` was renamed to `allowed_methods`.

Fix for #386

Can you take a look at it?
Sorry for any mistake 🙏 

Thanks!